### PR TITLE
refactor(ais_string): replace assert statements with ValueError exceptions

### DIFF
--- a/ais_area_notice/ais_string.py
+++ b/ais_area_notice/ais_string.py
@@ -6,7 +6,6 @@ character_bits: dict, lookup table for going from a single character to
   a 6 bit BitVector.
 """
 
-import logging
 import re
 
 from BitVector import BitVector
@@ -133,16 +132,17 @@ def encode(string: str, bit_size: int | None = None) -> BitVector:
         BitVector representing the string.
     """
     if bit_size:
-        assert bit_size % 6 == 0
+        if bit_size % 6 != 0:
+            raise ValueError(f"bit_size must be a multiple of 6, got {bit_size}")
     bv = BitVector(size=0)
     for char in string:
         bv += character_bits[char]
     if bit_size:
         if bit_size < len(bv):
-            logging.error(
-                'ERROR:  Too many bits in string: "%s %s %s"', string, bit_size, len(bv)
+            raise ValueError(
+                f'Too many bits in string: "{string}" requires {len(bv)} bits,'
+                f" max allowed is {bit_size}"
             )
-            assert False
         extra = bit_size - len(bv)
         bv += BitVector(size=extra)
 

--- a/tests/ais_string_test.py
+++ b/tests/ais_string_test.py
@@ -52,5 +52,11 @@ def test_encode_bit_size_padding() -> None:
 
 def test_encode_bit_size_too_small() -> None:
     """Test encoding AIS strings raises error when bit_size is too small."""
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError, match="Too many bits in string"):
         ais_string.Encode("AB", bit_size=6)
+
+
+def test_encode_bit_size_not_multiple_of_6() -> None:
+    """Test encoding AIS strings raises error when bit_size is not a multiple of 6."""
+    with pytest.raises(ValueError, match="bit_size must be a multiple of 6"):
+        ais_string.Encode("A", bit_size=7)


### PR DESCRIPTION
### Code Review & Suggestions for Improvement

  1. Consolidate Bit Size Validation in encode():
  The if bit_size: checks are performed at two separate points in encode(). Validation (checking bit_size % 6 != 0) can be consolidated upfront before building the bitvector.
  2. Standardize decode() Input Validation:
  decode() in ais_string.py documents that input bits must be a multiple of 6, but currently performs len(bits) // 6 without raising an exception if len(bits) % 6 != 0.
  Raising ValueError here would maintain parity with encode().
  3. AGENTS.md Rule Addition:
  Consider adding a rule in AGENTS.md Section 6 encouraging standard Python exceptions (ValueError, TypeError) over assert statements in runtime validation code so
  validations remain intact when Python is executed with optimization flags (-O).
