### PR TITLE
chore(pre-commit): update ruff-pre-commit hook version to v0.16.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.6
+    rev: v0.16.2
     hooks:
       - id: ruff-format
 

--- a/ais_area_notice/imo_001_22_area_notice.py
+++ b/ais_area_notice/imo_001_22_area_notice.py
@@ -2055,7 +2055,7 @@ class AreaNotice(BBM):
                 if msg_dict["checksum"] != nmea_checksum_hex(msg):
                     raise AisUnpackingException("Checksum failed")
                 msgs.append(msg_dict)
-        except (AttributeError, TypeError):
+        except AttributeError, TypeError:
             raise AisUnpackingException("one or more NMEA lines did were malformed (1)")
 
         bits_list = []

--- a/ais_area_notice/imo_001_26_environment.py
+++ b/ais_area_notice/imo_001_26_environment.py
@@ -2344,7 +2344,7 @@ class Environment(BBM):
                 if msg_dict["checksum"] != nmea_checksum_hex(msg):
                     raise AisUnpackingException("Checksum failed")
                 msgs.append(msg_dict)
-        except (AttributeError, TypeError):
+        except AttributeError, TypeError:
             raise AisUnpackingException(f"NMEA line malformed: {strings} ")
 
     def decode_bits(self, bits: BitVector, _year: int | None = None) -> None:

--- a/ais_area_notice/imo_001_31_met_hydro.py
+++ b/ais_area_notice/imo_001_31_met_hydro.py
@@ -345,7 +345,7 @@ class MetHydro31(BBM):
                 if msg_dict["checksum"] != nmea_checksum_hex(msg):
                     raise AisUnpackingException("Checksum failed")
                 msgs.append(msg_dict)
-        except (AttributeError, TypeError):
+        except AttributeError, TypeError:
             raise AisUnpackingException("one or more NMEA lines did were malformed (1)")
 
         # TODO(schwehr): Decode the NMEA.

--- a/ais_area_notice/m366_22.py
+++ b/ais_area_notice/m366_22.py
@@ -253,7 +253,7 @@ class AreaNotice:
                 if msg_dict["checksum"] != nmea_checksum_hex(msg):
                     raise AisUnpackingException("Checksum failed")
                 msgs.append(msg_dict)
-        except (AttributeError, TypeError):
+        except AttributeError, TypeError:
             raise AisUnpackingException("One or more NMEA lines were malformed (1)")
 
         bits_list: list[BitVector] = []

--- a/ais_area_notice/m367_22.py
+++ b/ais_area_notice/m367_22.py
@@ -831,7 +831,7 @@ class AreaNotice(BBM):
                 if msg_dict["checksum"] != nmea_checksum_hex(msg):
                     raise AisUnpackingException("Checksum failed")
                 msgs.append(msg_dict)
-        except (AttributeError, TypeError):
+        except AttributeError, TypeError:
             raise AisUnpackingException("One or more NMEA lines were malformed (1)")
 
         bits_list = []


### PR DESCRIPTION
Attempting to help with #39.

  ### Code Review & Proposed Improvements

  Per the AGENTS.md guidelines, here are 3 suggestions for improvement based on these changes:

  1. Include ruff in pyproject.toml Dev Dependencies:
      * AGENTS.md section 4 documents uv run ruff check --fix and uv run ruff format. Adding "ruff>=0.16.2" under [dependency-groups] dev in pyproject.toml ensures these standalone commands work directly with uv run without depending solely on  pre-commit binaries.
  2. NMEA Error Handling Test Cases:
      * In imo_001_22_area_notice.py (and related message files), NMEA sentence unpacking catches unpacking exceptions. Adding explicit test cases feeding malformed NMEA sentences into each message type will ensure these error paths are continuously validated across Python language versions.
  3. AGENTS.md Alignment:
      * Once ruff is added to dependency-groups.dev in pyproject.toml, update AGENTS.md Section 4 to mention syncing dev dependencies (uv sync) before invoking uv run ruff.