### PR TITLE
refactor(ruff): adopt datetime.UTC and re-enable UP017/UP032

### DIFF
--- a/ais_area_notice/imo_001_26_environment.py
+++ b/ais_area_notice/imo_001_26_environment.py
@@ -220,7 +220,7 @@ class SensorReport:
             return
 
         if not all(v is not None for v in (year, month, day, hour, minute)):
-            now = datetime.datetime.now(datetime.timezone.utc)
+            now = datetime.datetime.now(datetime.UTC)
             # TODO(schwehr): Switch to year = year or now.year.
             if year is None:
                 year = now.year
@@ -332,7 +332,7 @@ class SensorReport:
         self.site_id = int(bits[20:27])
 
         if year is None:
-            now = datetime.datetime.now(datetime.timezone.utc)
+            now = datetime.datetime.now(datetime.UTC)
             year = now.year
             month = now.month
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,8 +85,6 @@ ignore = [
     "SIM102",  # Use a single if statement instead of nested if statements
     "SIM117",  # Use a single with statement instead of nested with statements
     "SIM118",  # Use key in dict instead of key in dict.keys()
-    "UP017",  # Use datetime.UTC alias instead of datetime.timezone.utc
-    "UP032",  # Use f-string instead of format call
 ]
 
 [tool.coverage.run]

--- a/tests/benchmarks_test.py
+++ b/tests/benchmarks_test.py
@@ -127,7 +127,7 @@ def test_benchmark_binary_signed_int_from_bv(
 def _create_area_notice_22() -> area_notice_22.AreaNotice:
     an = area_notice_22.AreaNotice(
         area_type=0,
-        when=datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
+        when=datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.UTC),
         duration=60,
         link_id=1,
         source_mmsi=123456789,
@@ -168,7 +168,7 @@ def test_benchmark_imo_001_22_area_notice_decode(
     def _decode() -> area_notice_22.AreaNotice:
         decoded = area_notice_22.AreaNotice(
             area_type=0,
-            when=datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
+            when=datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.UTC),
             duration=60,
             link_id=1,
             source_mmsi=123456789,
@@ -206,7 +206,7 @@ def test_benchmark_imo_001_22_area_notice_geo_interface(
 
 def _create_environment_26() -> environment_26.Environment:
     env = environment_26.Environment(source_mmsi=123456789)
-    dt = datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    dt = datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
     env.add_sensor_report(
         environment_26.SensorReportLocation(
             site_id=1,
@@ -402,7 +402,7 @@ def test_benchmark_m366_22_circle_decode_bits(
 
 
 def _create_m367_22() -> m367_22.AreaNotice:
-    now = datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    now = datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
     an = m367_22.AreaNotice(
         area_type=1, when=now, duration_min=60, link_id=10, mmsi=123456789
     )
@@ -437,7 +437,7 @@ def test_benchmark_m367_22_decode(benchmark: BenchmarkFixture) -> None:
     bits = an.get_bits(include_bin_hdr=True)
 
     def _decode() -> m367_22.AreaNotice:
-        now = datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        now = datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
         decoded = m367_22.AreaNotice(
             area_type=1, when=now, duration_min=60, link_id=10, mmsi=123456789
         )


### PR DESCRIPTION
Replace datetime.timezone.utc with datetime.UTC and enable UP017 and UP032 rules in pyproject.toml.