### PR TITLE
refactor(tests): replace setattr with direct attribute assignment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ skips = ["B101", "B311"]
 
 [tool.ruff.lint]
 ignore = [
-    "B010",  # Do not call setattr with a constant attribute name
     "DTZ001",  # The use of datetime.datetime() without tzinfo argument is not allowed
     "DTZ007",  # Naive datetime constructed using strptime() without %z format
     "EXE001",  # Shebang is present but file is not executable

--- a/tests/coverage_completion_test.py
+++ b/tests/coverage_completion_test.py
@@ -93,7 +93,7 @@ def test_area_notice_subarea_base_methods() -> None:
 def test_subarea_kml_with_custom_name() -> None:
     """Test KML generation when notice has a custom name."""
     an = AreaNotice(area_type=1, when=NOW, duration=60)
-    setattr(an, "name", "CustomAreaNoticeName")
+    an.name = "CustomAreaNoticeName"
     sa = AreaNoticeCirclePt(lon=-70.0, lat=42.0, radius=500)
     an.add_subarea(sa)
     kml_str = an.kml()

--- a/tests/imo_001_31_met_hydro_test.py
+++ b/tests/imo_001_31_met_hydro_test.py
@@ -187,13 +187,13 @@ def test_eq_branches() -> None:
     mh2 = met_hydro.MetHydro31(source_mmsi=123456789)
 
     # Line 215: len(self.__dict__) != len(other.__dict__)
-    setattr(mh2, "extra_attr", 123)
+    mh2.extra_attr = 123  # type: ignore[attr-defined]
     assert mh1 != mh2
     delattr(mh2, "extra_attr")
 
     # Line 220: key not in other.__dict__
-    setattr(mh1, "attr_a", 1)
-    setattr(mh2, "attr_b", 1)
+    mh1.attr_a = 1  # type: ignore[attr-defined]
+    mh2.attr_b = 1  # type: ignore[attr-defined]
     assert mh1 != mh2
     delattr(mh1, "attr_a")
     delattr(mh2, "attr_b")


### PR DESCRIPTION
- Remove ruff rule B010 from ignore list in pyproject.toml
- Replace setattr() calls with direct attribute assignment in coverage_completion_test.py and imo_001_31_met_hydro_test.py
- Add type: ignore[attr-defined] to dynamic attribute assignments in test_eq_branches to satisfy mypy