### PR TITLE
fix(datetime): make all datetime instantiations UTC timezone-aware

### DIFF
--- a/ais_area_notice/build_samples.py
+++ b/ais_area_notice/build_samples.py
@@ -346,7 +346,7 @@ def point(lon: float, lat: float, zone_type: int, kmlfile: TextIO) -> None:
     print("# Point")
     pt1 = an.AreaNotice(
         zone_type,
-        datetime.datetime(2011, 7, 6, 0, 0, 0),
+        datetime.datetime(2011, 7, 6, 0, 0, 0, tzinfo=datetime.UTC),
         60,
         10,
         source_mmsi=123456789,
@@ -407,7 +407,7 @@ def main() -> None:
     zone_type = 2
     circle1 = an.AreaNotice(
         an.notice_type["cau_mammals_not_obs"],
-        datetime.datetime(2011, 7, 6, 1, 10, 0),
+        datetime.datetime(2011, 7, 6, 1, 10, 0, tzinfo=datetime.UTC),
         60,
         10,
         source_mmsi=123456789,
@@ -420,7 +420,7 @@ def main() -> None:
 
     circle1 = an.AreaNotice(
         an.notice_type["cau_mammals_reduce_speed"],
-        datetime.datetime(2011, 7, 6, 2, 15, 0),
+        datetime.datetime(2011, 7, 6, 2, 15, 0, tzinfo=datetime.UTC),
         60,
         10,
         source_mmsi=123456789,
@@ -435,7 +435,7 @@ def main() -> None:
     # Next two make sure that code can handle both byte aligned test data.
     circle_aligned = an.AreaNotice(
         an.notice_type["dis_collision"],
-        datetime.datetime(2011, 2, 6, 2, 15, 0),
+        datetime.datetime(2011, 2, 6, 2, 15, 0, tzinfo=datetime.UTC),
         60,
         10,
         source_mmsi=366786,
@@ -449,7 +449,7 @@ def main() -> None:
 
     circles_aligned = an.AreaNotice(
         an.notice_type["dis_pollution"],
-        datetime.datetime(2011, 2, 6, 2, 15, 0),
+        datetime.datetime(2011, 2, 6, 2, 15, 0, tzinfo=datetime.UTC),
         60,
         10,
         source_mmsi=366786,
@@ -464,7 +464,7 @@ def main() -> None:
 
     circles = an.AreaNotice(
         an.notice_type["res_drifting_mines"],
-        datetime.datetime(2011, 2, 6, 2, 15, 0),
+        datetime.datetime(2011, 2, 6, 2, 15, 0, tzinfo=datetime.UTC),
         60,
         10,
         source_mmsi=366786,
@@ -485,7 +485,7 @@ def main() -> None:
 
     rect1 = an.AreaNotice(
         zone_type,
-        datetime.datetime(2011, 7, 6, 5, 31, 0),
+        datetime.datetime(2011, 7, 6, 5, 31, 0, tzinfo=datetime.UTC),
         60,
         10,
         source_mmsi=123456789,
@@ -499,7 +499,7 @@ def main() -> None:
 
     sec1 = an.AreaNotice(
         zone_type,
-        datetime.datetime(2011, 7, 6, 12, 49, 0),
+        datetime.datetime(2011, 7, 6, 12, 49, 0, tzinfo=datetime.UTC),
         60,
         10,
         source_mmsi=123456789,
@@ -513,7 +513,7 @@ def main() -> None:
 
     line1 = an.AreaNotice(
         zone_type,
-        datetime.datetime(2011, 7, 6, 15, 1, 0),
+        datetime.datetime(2011, 7, 6, 15, 1, 0, tzinfo=datetime.UTC),
         60,
         10,
         source_mmsi=123456789,
@@ -527,7 +527,7 @@ def main() -> None:
 
     poly1 = an.AreaNotice(
         zone_type,
-        datetime.datetime(2011, 7, 6, 20, 59, 0),
+        datetime.datetime(2011, 7, 6, 20, 59, 0, tzinfo=datetime.UTC),
         60,
         10,
         source_mmsi=123456789,
@@ -541,7 +541,7 @@ def main() -> None:
 
     text1 = an.AreaNotice(
         zone_type,
-        datetime.datetime(2011, 7, 6, 23, 59, 0),
+        datetime.datetime(2011, 7, 6, 23, 59, 0, tzinfo=datetime.UTC),
         60,
         10,
         source_mmsi=123456789,
@@ -558,7 +558,7 @@ def main() -> None:
 
     one_of_each = an.AreaNotice(
         zone_type,
-        datetime.datetime(2011, 11, 29, 0, 1, 0),
+        datetime.datetime(2011, 11, 29, 0, 1, 0, tzinfo=datetime.UTC),
         60,
         10,
         source_mmsi=123456789,
@@ -579,7 +579,7 @@ def main() -> None:
 
     many_sectors = an.AreaNotice(
         zone_type,
-        datetime.datetime(2011, 12, 31, 0, 0, 0),
+        datetime.datetime(2011, 12, 31, 0, 0, 0, tzinfo=datetime.UTC),
         60,
         10,
         source_mmsi=123456789,
@@ -599,7 +599,7 @@ def main() -> None:
 
     full1 = an.AreaNotice(
         zone_type,
-        datetime.datetime(2011, 1, 1, 0, 1, 0),
+        datetime.datetime(2011, 1, 1, 0, 1, 0, tzinfo=datetime.UTC),
         60,
         10,
         source_mmsi=123456789,
@@ -622,7 +622,7 @@ def main() -> None:
     lon_off: float = 0
     rr = an.AreaNotice(
         zone_type,
-        datetime.datetime(2010, 9, 8, 17, 0, 0),
+        datetime.datetime(2010, 9, 8, 17, 0, 0, tzinfo=datetime.UTC),
         60,
         10,
         source_mmsi=200000000,
@@ -646,7 +646,7 @@ def main() -> None:
 
     rr2 = an.AreaNotice(
         zone_type,
-        datetime.datetime(2010, 9, 8, 17, 0, 0),
+        datetime.datetime(2010, 9, 8, 17, 0, 0, tzinfo=datetime.UTC),
         60,
         10,
         source_mmsi=200000000,
@@ -670,7 +670,7 @@ def main() -> None:
 
     rr3 = an.AreaNotice(
         zone_type,
-        datetime.datetime(2010, 9, 8, 17, 0, 0),
+        datetime.datetime(2010, 9, 8, 17, 0, 0, tzinfo=datetime.UTC),
         60,
         10,
         source_mmsi=200000000,
@@ -696,7 +696,7 @@ def main() -> None:
     print("\n# rect-multi-scale")
     rect1 = an.AreaNotice(
         zone_type,
-        datetime.datetime(2011, 7, 6, 0, 0, 0),
+        datetime.datetime(2011, 7, 6, 0, 0, 0, tzinfo=datetime.UTC),
         60,
         10,
         source_mmsi=123456789,
@@ -754,7 +754,7 @@ def main() -> None:
         zone_type = 2
         circle1 = an.AreaNotice(
             an.notice_type["cau_mammals_not_obs"],
-            datetime.datetime(2011, 7, 6, 1, 10, 0),
+            datetime.datetime(2011, 7, 6, 1, 10, 0, tzinfo=datetime.UTC),
             60,
             10,
             source_mmsi=123456789,
@@ -767,7 +767,7 @@ def main() -> None:
 
         circle2 = an.AreaNotice(
             an.notice_type["cau_mammals_reduce_speed"],
-            datetime.datetime(2011, 7, 6, 1, 10, 0),
+            datetime.datetime(2011, 7, 6, 1, 10, 0, tzinfo=datetime.UTC),
             60,
             10,
             source_mmsi=123456789,
@@ -780,7 +780,7 @@ def main() -> None:
 
         rec1 = an.AreaNotice(
             zone_type,
-            datetime.datetime(2011, 7, 6, 1, 10, 0),
+            datetime.datetime(2011, 7, 6, 1, 10, 0, tzinfo=datetime.UTC),
             60,
             10,
             source_mmsi=123456789,
@@ -793,7 +793,7 @@ def main() -> None:
 
         poly1 = an.AreaNotice(
             zone_type,
-            datetime.datetime(2011, 7, 6, 1, 10, 0),
+            datetime.datetime(2011, 7, 6, 1, 10, 0, tzinfo=datetime.UTC),
             60,
             10,
             source_mmsi=123456789,
@@ -811,7 +811,7 @@ def main() -> None:
 
         line1 = an.AreaNotice(
             zone_type,
-            datetime.datetime(2011, 7, 6, 1, 10, 0),
+            datetime.datetime(2011, 7, 6, 1, 10, 0, tzinfo=datetime.UTC),
             60,
             10,
             source_mmsi=123456789,
@@ -830,7 +830,7 @@ def main() -> None:
         # Free text in circle notice
         pt1 = an.AreaNotice(
             an.notice_type["cau_mammals_not_obs"],
-            datetime.datetime(2011, 7, 6, 1, 10, 0),
+            datetime.datetime(2011, 7, 6, 1, 10, 0, tzinfo=datetime.UTC),
             60,
             10,
             source_mmsi=123456789,
@@ -844,7 +844,7 @@ def main() -> None:
         # Free text in circle notice
         pt1 = an.AreaNotice(
             an.notice_type["cau_mammals_not_obs"],
-            datetime.datetime(2011, 7, 6, 1, 10, 0),
+            datetime.datetime(2011, 7, 6, 1, 10, 0, tzinfo=datetime.UTC),
             60,
             10,
             source_mmsi=123456789,
@@ -859,7 +859,7 @@ def main() -> None:
         # Sector
         sec1 = an.AreaNotice(
             zone_type,
-            datetime.datetime(2011, 7, 6, 1, 10, 0),
+            datetime.datetime(2011, 7, 6, 1, 10, 0, tzinfo=datetime.UTC),
             60,
             10,
             source_mmsi=123456789,
@@ -880,7 +880,7 @@ def main() -> None:
         start = sbnms_boundary[0]
         sbnms1 = an.AreaNotice(
             zone_type,
-            datetime.datetime(2010, 9, 8, 20, 0, 17),
+            datetime.datetime(2010, 9, 8, 20, 0, 17, tzinfo=datetime.UTC),
             60,
             10,
             source_mmsi=369871000,

--- a/ais_area_notice/imo_001_22_area_notice.py
+++ b/ais_area_notice/imo_001_22_area_notice.py
@@ -1850,6 +1850,7 @@ class AreaNotice(BBM):
                 day=when.day,
                 hour=when.hour,
                 minute=when.minute,
+                tzinfo=when.tzinfo or datetime.UTC,
             )
             assert duration < 2**18 - 1
             self.duration = duration
@@ -2099,6 +2100,7 @@ class AreaNotice(BBM):
             day=r["utc_day"],
             hour=r["utc_hour"],
             minute=r["utc_min"],
+            tzinfo=datetime.UTC,
         )
         self.duration = r["duration_min"]
         self.link_id = r["link_id"]

--- a/ais_area_notice/imo_001_26_environment.py
+++ b/ais_area_notice/imo_001_26_environment.py
@@ -288,9 +288,13 @@ class SensorReport:
         Returns:
             A datetime object for the sensor report timestamp.
         """
-        # TODO(schwehr): Add the UTC timezone?
         return datetime.datetime(
-            self.year, self.month, self.day, self.hour, self.minute
+            self.year,
+            self.month,
+            self.day,
+            self.hour,
+            self.minute,
+            tzinfo=datetime.UTC,
         )
 
     def __unicode__(self) -> str:

--- a/ais_area_notice/m366_22.py
+++ b/ais_area_notice/m366_22.py
@@ -199,7 +199,12 @@ class AreaNotice:
             assert when is not None
             # Leave out seconds.
             self.when = datetime.datetime(
-                when.year, when.month, when.day, when.hour, when.minute
+                when.year,
+                when.month,
+                when.day,
+                when.hour,
+                when.minute,
+                tzinfo=when.tzinfo or datetime.UTC,
             )
             self.duration_min = duration_min
             self.link_id = link_id
@@ -287,7 +292,9 @@ class AreaNotice:
         minute = db.get_int(6)
         # TODO(schwehr): Handle year boundary.
         now = datetime.datetime.now(datetime.UTC)
-        self.when = datetime.datetime(now.year, month, day, hour, minute)
+        self.when = datetime.datetime(
+            now.year, month, day, hour, minute, tzinfo=datetime.UTC
+        )
         self.duration_min = db.get_int(18)
         # self.spare2 = db.GetInt(3)
         start_sub_areas = 111

--- a/ais_area_notice/m367_22.py
+++ b/ais_area_notice/m367_22.py
@@ -707,7 +707,12 @@ class AreaNotice(BBM):
             assert when is not None
             # Leave out seconds.
             self.when = datetime.datetime(
-                when.year, when.month, when.day, when.hour, when.minute
+                when.year,
+                when.month,
+                when.day,
+                when.hour,
+                when.minute,
+                tzinfo=when.tzinfo or datetime.UTC,
             )
             assert duration_min is not None
             self.duration_min = duration_min
@@ -849,7 +854,9 @@ class AreaNotice(BBM):
         minute = db.get_int(6)
         # TODO(schwehr): Handle year boundary.
         now = datetime.datetime.now(datetime.UTC)
-        self.when = datetime.datetime(now.year, month, day, hour, minute)
+        self.when = datetime.datetime(
+            now.year, month, day, hour, minute, tzinfo=datetime.UTC
+        )
         self.duration_min = db.get_int(18)
         self.spare2 = db.get_int(3)
         db.verify(120)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ skips = ["B101", "B311"]
 
 [tool.ruff.lint]
 ignore = [
-    "DTZ001",  # The use of datetime.datetime() without tzinfo argument is not allowed
     "DTZ007",  # Naive datetime constructed using strptime() without %z format
     "EXE001",  # Shebang is present but file is not executable
     "EXE002",  # The file is executable but no shebang is present

--- a/tests/coverage_completion_test.py
+++ b/tests/coverage_completion_test.py
@@ -30,7 +30,7 @@ from ais_area_notice.imo_001_31_met_hydro import MetHydro31
 from tests.imo_001_22_area_notice_test import assert_almost_equal_geojson
 from tests.imo_001_31_met_hydro_test import random_msg as random_met_hydro
 
-NOW = datetime.datetime(2026, 1, 1, 12, 0, 0)
+NOW = datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
 
 
 def test_bbm_base_get_bits_not_implemented() -> None:

--- a/tests/imo_001_22_area_notice_test.py
+++ b/tests/imo_001_22_area_notice_test.py
@@ -417,7 +417,7 @@ class TestBitDecoding:
         year = datetime.datetime.now(datetime.UTC).year
         pt1 = area_notice.AreaNotice(
             area_notice.notice_type["cau_mammals_not_obs"],
-            datetime.datetime(year, 8, 6, 0, 1, 0),
+            datetime.datetime(year, 8, 6, 0, 1, 0, tzinfo=datetime.UTC),
             60,
             10,
             source_mmsi=445566778,
@@ -439,7 +439,7 @@ class TestBitDecoding:
         circle1 = area_notice.AreaNotice(
             area_notice.notice_type["cau_mammals_reduce_speed"],
             # Do not use seconds.  Can only use minutes.
-            datetime.datetime(now.year, 7, 6, 0, 0, 0),
+            datetime.datetime(now.year, 7, 6, 0, 0, 0, tzinfo=datetime.UTC),
             60,
             10,
             source_mmsi=2,
@@ -458,7 +458,15 @@ class TestBitDecoding:
         """Test Area Notice encoding and decoding roundtrip for rectangle subarea."""
         rect = area_notice.AreaNotice(
             area_notice.notice_type["cau_mammals_reduce_speed"],
-            datetime.datetime(datetime.datetime.now(datetime.UTC).year, 7, 6, 0, 0, 4),
+            datetime.datetime(
+                datetime.datetime.now(datetime.UTC).year,
+                7,
+                6,
+                0,
+                0,
+                4,
+                tzinfo=datetime.UTC,
+            ),
             60,
             10,
             source_mmsi=123,
@@ -475,7 +483,15 @@ class TestBitDecoding:
         """Test Area Notice encoding and decoding roundtrip for sector subarea."""
         sec1 = area_notice.AreaNotice(
             area_notice.notice_type["cau_habitat_reduce_speed"],
-            datetime.datetime(datetime.datetime.now(datetime.UTC).year, 7, 6, 0, 0, 4),
+            datetime.datetime(
+                datetime.datetime.now(datetime.UTC).year,
+                7,
+                6,
+                0,
+                0,
+                4,
+                tzinfo=datetime.UTC,
+            ),
             60,
             10,
             source_mmsi=456,
@@ -491,7 +507,15 @@ class TestBitDecoding:
         """Test Area Notice encoding and decoding roundtrip for polyline subarea."""
         line1 = area_notice.AreaNotice(
             area_notice.notice_type["report_of_icing"],
-            datetime.datetime(datetime.datetime.now(datetime.UTC).year, 7, 6, 0, 0, 4),
+            datetime.datetime(
+                datetime.datetime.now(datetime.UTC).year,
+                7,
+                6,
+                0,
+                0,
+                4,
+                tzinfo=datetime.UTC,
+            ),
             60,
             10,
             source_mmsi=123456,
@@ -506,7 +530,15 @@ class TestBitDecoding:
         """Test Area Notice encoding and decoding roundtrip for polygon subarea."""
         poly1 = area_notice.AreaNotice(
             area_notice.notice_type["cau_divers"],
-            datetime.datetime(datetime.datetime.now(datetime.UTC).year, 7, 6, 0, 0, 4),
+            datetime.datetime(
+                datetime.datetime.now(datetime.UTC).year,
+                7,
+                6,
+                0,
+                0,
+                4,
+                tzinfo=datetime.UTC,
+            ),
             60,
             10,
             source_mmsi=987123456,
@@ -523,7 +555,15 @@ class TestBitDecoding:
         """Test Area Notice encoding and decoding roundtrip for free text subarea."""
         text1 = area_notice.AreaNotice(
             area_notice.notice_type["res_military_ops"],
-            datetime.datetime(datetime.datetime.now(datetime.UTC).year, 7, 6, 0, 4, 0),
+            datetime.datetime(
+                datetime.datetime.now(datetime.UTC).year,
+                7,
+                6,
+                0,
+                4,
+                0,
+                tzinfo=datetime.UTC,
+            ),
             60,
             10,
             source_mmsi=300000000,
@@ -546,7 +586,15 @@ class TestBitDecoding2:
         # One of each.
         notice = area_notice.AreaNotice(
             area_notice.notice_type["cau_mammals_not_obs"],
-            datetime.datetime(datetime.datetime.now(datetime.UTC).year, 7, 6, 0, 0, 4),
+            datetime.datetime(
+                datetime.datetime.now(datetime.UTC).year,
+                7,
+                6,
+                0,
+                0,
+                4,
+                tzinfo=datetime.UTC,
+            ),
             60,
             10,
             source_mmsi=666555444,
@@ -576,7 +624,15 @@ class TestBitDecoding2:
         """Test Area Notice with multiple sector subareas and max subarea limit."""
         notice = area_notice.AreaNotice(
             area_notice.notice_type["cau_mammals_not_obs"],
-            datetime.datetime(datetime.datetime.now(datetime.UTC).year, 7, 6, 0, 0, 4),
+            datetime.datetime(
+                datetime.datetime.now(datetime.UTC).year,
+                7,
+                6,
+                0,
+                0,
+                4,
+                tzinfo=datetime.UTC,
+            ),
             60,
             10,
             source_mmsi=1,
@@ -623,7 +679,15 @@ class TestBitDecoding2:
         """Test Area Notice with multi-part text subareas and merged text retrieval."""
         notice = area_notice.AreaNotice(
             area_notice.notice_type["cau_mammals_not_obs"],
-            datetime.datetime(datetime.datetime.now(datetime.UTC).year, 7, 6, 0, 0, 4),
+            datetime.datetime(
+                datetime.datetime.now(datetime.UTC).year,
+                7,
+                6,
+                0,
+                0,
+                4,
+                tzinfo=datetime.UTC,
+            ),
             60,
             10,
             source_mmsi=2,
@@ -692,7 +756,15 @@ class TestWhaleNotices:
         zone_type = area_notice.notice_type["cau_mammals_not_obs"]
         circle = area_notice.AreaNotice(
             zone_type,
-            datetime.datetime(datetime.datetime.now(datetime.UTC).year, 7, 6, 0, 0, 4),
+            datetime.datetime(
+                datetime.datetime.now(datetime.UTC).year,
+                7,
+                6,
+                0,
+                0,
+                4,
+                tzinfo=datetime.UTC,
+            ),
             60,
             10,
             source_mmsi=123456789,
@@ -726,7 +798,15 @@ class TestWhaleNotices:
         zone_type = area_notice.notice_type["cau_mammals_reduce_speed"]
         circle = area_notice.AreaNotice(
             zone_type,
-            datetime.datetime(datetime.datetime.now(datetime.UTC).year, 7, 6, 0, 0, 4),
+            datetime.datetime(
+                datetime.datetime.now(datetime.UTC).year,
+                7,
+                6,
+                0,
+                0,
+                4,
+                tzinfo=datetime.UTC,
+            ),
             60,
             10,
             source_mmsi=123456789,
@@ -820,7 +900,7 @@ def test_get_aivdm_validation_errors() -> None:
 
 def test_get_aivdm_byte_align_and_normal_form_and_sequence_wrap() -> None:
     """Test AIVDM byte alignment, normal form, and sequence number wrap-around."""
-    when = datetime.datetime(2026, 8, 7, 0, 0, 0)
+    when = datetime.datetime(2026, 8, 7, 0, 0, 0, tzinfo=datetime.UTC)
     an = area_notice.AreaNotice(
         area_type=1, when=when, duration=60, source_mmsi=123456789
     )
@@ -879,7 +959,7 @@ def test_area_notice_kml_options(
     monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
 ) -> None:
     """Test KML generation options, styles, and empty geometry handling."""
-    when = datetime.datetime(2026, 8, 7, 0, 0)
+    when = datetime.datetime(2026, 8, 7, 0, 0, tzinfo=datetime.UTC)
     an = area_notice.AreaNotice(
         area_type=1, when=when, duration=60, source_mmsi=123456789
     )
@@ -1184,7 +1264,7 @@ def test_area_notice_init_and_methods_and_errors() -> None:
     with pytest.raises(AssertionError):
         area_notice.AreaNotice()
 
-    when = datetime.datetime(2026, 8, 7, 0, 0)
+    when = datetime.datetime(2026, 8, 7, 0, 0, tzinfo=datetime.UTC)
     an = area_notice.AreaNotice(
         area_type=1, when=when, duration=60, source_mmsi=123456789
     )
@@ -1264,7 +1344,7 @@ def test_area_notice_init_and_methods_and_errors() -> None:
 
 def test_area_notice_decode_nmea_errors() -> None:
     """Test AreaNotice NMEA sentence decoding error handling."""
-    when = datetime.datetime(2026, 8, 7, 0, 0)
+    when = datetime.datetime(2026, 8, 7, 0, 0, tzinfo=datetime.UTC)
     an = area_notice.AreaNotice(
         area_type=1, when=when, duration=60, source_mmsi=123456789
     )
@@ -1282,7 +1362,7 @@ def test_area_notice_decode_nmea_errors() -> None:
 
 def test_subarea_factory_and_get_shapes() -> None:
     """Test subarea factory shape instantiation and sequencing validation."""
-    when = datetime.datetime(2026, 8, 7, 0, 0)
+    when = datetime.datetime(2026, 8, 7, 0, 0, tzinfo=datetime.UTC)
     an = area_notice.AreaNotice(
         area_type=1, when=when, duration=60, source_mmsi=123456789
     )
@@ -1323,7 +1403,7 @@ def test_subarea_factory_and_get_shapes() -> None:
 
 def test_message_2_fetcherformatter_and_normqueue() -> None:
     """Test CSV message formatting and NormQueue multi-sentence NMEA reassembly."""
-    when = datetime.datetime(2026, 8, 7, 0, 0)
+    when = datetime.datetime(2026, 8, 7, 0, 0, tzinfo=datetime.UTC)
     an = area_notice.AreaNotice(
         area_type=1, when=when, duration=60, source_mmsi=123456789
     )
@@ -1402,7 +1482,7 @@ def test_nmea_checksum_hex_invalid_length(
 
 def test_main_cli(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> None:
     """Test CLI main entry point sentence parsing and KML output file creation."""
-    when = datetime.datetime(2026, 8, 7, 0, 0)
+    when = datetime.datetime(2026, 8, 7, 0, 0, tzinfo=datetime.UTC)
     an = area_notice.AreaNotice(
         area_type=1, when=when, duration=60, source_mmsi=123456789
     )

--- a/tests/imo_001_26_environment_test.py
+++ b/tests/imo_001_26_environment_test.py
@@ -61,7 +61,9 @@ def random_date() -> datetime.datetime:
     hour = random.randint(0, 23)
     minute = random.randint(0, 59)
     date_str = f"{year:4d}-{j_day:03d}T{hour:02d}:{minute:02d}"
-    return datetime.datetime.strptime(date_str, "%Y-%jT%H:%M")
+    return datetime.datetime.strptime(date_str, "%Y-%jT%H:%M").replace(
+        tzinfo=datetime.UTC
+    )
 
 
 def random_loc() -> env.SensorReportLocation:
@@ -450,7 +452,7 @@ class TestSensorReports:
             minute=0,
             site_id=0,
         )
-        assert sr.get_date() == datetime.datetime(2011, 1, 1, 0, 0)
+        assert sr.get_date() == datetime.datetime(2011, 1, 1, 0, 0, tzinfo=datetime.UTC)
 
         sr = env.SensorReport(
             report_type,
@@ -461,7 +463,9 @@ class TestSensorReports:
             minute=59,
             site_id=0,
         )
-        assert sr.get_date() == datetime.datetime(2011, 12, 31, 23, 59)
+        assert sr.get_date() == datetime.datetime(
+            2011, 12, 31, 23, 59, tzinfo=datetime.UTC
+        )
 
     def test_sr_eq(self) -> None:
         """SensorReport equality operator"""

--- a/tests/m366_22_test.py
+++ b/tests/m366_22_test.py
@@ -75,7 +75,7 @@ def test_area_notice_circle_init_and_get_bits() -> None:
 
 def test_add_subarea_no_areas_attr_and_max_areas_exceeded() -> None:
     """Test adding subareas handles missing areas attribute and enforces maximum limit."""
-    when = datetime.datetime(2026, 9, 4, 15, 25)
+    when = datetime.datetime(2026, 9, 4, 15, 25, tzinfo=datetime.UTC)
     an = m366_22.AreaNotice(area_type=1, when=when)
     del an.areas
     circle = m366_22.AreaNoticeCircle(lon=1.0, lat=-2.0, radius=4, precision=3)

--- a/tests/m367_22_test.py
+++ b/tests/m367_22_test.py
@@ -92,7 +92,7 @@ class TestAreaNotice:
         assert area_notice.link_id == link_id
         assert area_notice.area_type == area_type
         year = datetime.datetime.now(datetime.UTC).year
-        timestamp_dt = datetime.datetime(year, *timestamp)
+        timestamp_dt = datetime.datetime(year, *timestamp, tzinfo=datetime.UTC)
         assert area_notice.when == timestamp_dt
         assert area_notice.duration_min == duration
         if "spare2" in area_notice.__dict__:
@@ -306,7 +306,7 @@ class TestAreaNotice:
         """Test AreaNotice with circle subarea encoding and NMEA generation."""
         # Test against 'Sample AN Data RTCMv1.xlsx' circle
         year = datetime.datetime.now(datetime.UTC).year
-        when = datetime.datetime(year, 9, 4, 15, 25)
+        when = datetime.datetime(year, 9, 4, 15, 25, tzinfo=datetime.UTC)
 
         # Match the USCG sample
         duration = 2880
@@ -404,7 +404,7 @@ class TestAreaNotice:
     def test_rectangle_encode(self) -> None:
         """Test AreaNotice with rectangle subarea encoding and NMEA generation."""
         year = datetime.datetime.now(datetime.UTC).year
-        when = datetime.datetime(year, 9, 4, 15, 25)
+        when = datetime.datetime(year, 9, 4, 15, 25, tzinfo=datetime.UTC)
 
         duration = 360
         scale_factor = 10
@@ -605,7 +605,7 @@ class TestAreaNotice:
 
     def test_add_subarea_no_areas_attr_and_max_areas_exceeded(self) -> None:
         """Test subarea addition limits and attribute handling."""
-        when = datetime.datetime(2026, 9, 4, 15, 25)
+        when = datetime.datetime(2026, 9, 4, 15, 25, tzinfo=datetime.UTC)
         an = AreaNotice(
             area_type=13, when=when, duration_min=60, link_id=1, mmsi=366123456
         )
@@ -624,7 +624,7 @@ class TestAreaNotice:
 
     def test_get_bits_include_bin_hdr_and_too_large_error(self) -> None:
         """Test binary header inclusion and message size overflow check."""
-        when = datetime.datetime(2026, 9, 4, 15, 25)
+        when = datetime.datetime(2026, 9, 4, 15, 25, tzinfo=datetime.UTC)
         an = AreaNotice(
             area_type=13, when=when, duration_min=60, link_id=1, mmsi=366123456
         )
@@ -672,7 +672,7 @@ class TestAreaNotice:
 
     def test_subarea_factory_invalid_preceding_shape(self) -> None:
         """Test subarea factory throws error for invalid shape sequence."""
-        when = datetime.datetime(2026, 9, 4, 15, 25)
+        when = datetime.datetime(2026, 9, 4, 15, 25, tzinfo=datetime.UTC)
         an = AreaNotice(
             area_type=13, when=when, duration_min=60, link_id=1, mmsi=366123456
         )
@@ -790,7 +790,7 @@ class TestAreaNotice:
 
 def test_diff_area_notice() -> None:
     """Test DiffAreaNotice comparison helper."""
-    now = datetime.datetime(2026, 1, 1, 12, 0)
+    now = datetime.datetime(2026, 1, 1, 12, 0, tzinfo=datetime.UTC)
     an1 = AreaNotice(area_type=1, when=now, duration_min=60, link_id=1, mmsi=123456789)
     an2 = AreaNotice(area_type=2, when=now, duration_min=120, link_id=1, mmsi=123456789)
     diff = DiffAreaNotice(an1, an2)


### PR DESCRIPTION
Enforce DTZ001 compliance across all message encoders, sample builders, and automated test suites by supplying explicit tzinfo=datetime.UTC or preserving existing timezone information when constructing datetime.datetime objects.