### PR TITLE
chore(config): un-ignore ruff DTZ007 rule in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ skips = ["B101", "B311"]
 
 [tool.ruff.lint]
 ignore = [
-    "DTZ007",  # Naive datetime constructed using strptime() without %z format
     "EXE001",  # Shebang is present but file is not executable
     "EXE002",  # The file is executable but no shebang is present
     "F601",  # Dictionary key literal repeated


### PR DESCRIPTION
Enforce DTZ007 (naive datetime constructed using strptime without %z format) across the project to maintain strict UTC timezone awareness.