### PR TITLE
refactor(shebang): remove shebangs from non-executable Python modules

### DIFF
--- a/ais_area_notice/build_samples.py
+++ b/ais_area_notice/build_samples.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Generate sample data for Area Notice / Zone msg."""
 
 import datetime

--- a/ais_area_notice/imo_001_22_area_notice.py
+++ b/ais_area_notice/imo_001_22_area_notice.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """Trying to do a more sane design for AIS BBM message.
 
 https://vislab-ccom.unh.edu/~schwehr/papers/2010-IMO-SN.1-Circ.289.pdf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ skips = ["B101", "B311"]
 
 [tool.ruff.lint]
 ignore = [
-    "EXE001",  # Shebang is present but file is not executable
     "EXE002",  # The file is executable but no shebang is present
     "F601",  # Dictionary key literal repeated
     "F821",  # Undefined name


### PR DESCRIPTION
Remove shebang lines from build_samples.py and imo_001_22_area_notice.py and un-ignore EXE001 rule in pyproject.toml to resolve ruff EXE001 warnings for non-executable Python files.