### PR TITLE
chore(config): un-ignore ruff F601 rule in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ skips = ["B101", "B311"]
 
 [tool.ruff.lint]
 ignore = [
-    "F601",  # Dictionary key literal repeated
     "F821",  # Undefined name
 ]
 


### PR DESCRIPTION
Enforce ruff rule F601 (dictionary key literal repeated) across the project to prevent duplicate keys in dictionary literals.