### PR TITLE
ci(pre-commit): re-enable lychee hook

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,37 @@
+name: Link Check
+
+on:
+  schedule:
+    - cron: "0 4 * * 1" # Weekly on Monday at 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  link-check:
+    name: "Check Links (lychee)"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run lychee link checker
+        run: uv run pre-commit run lychee --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,3 @@
-ci:
-  skip:
-    - lychee
-    - mypy
-
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,8 @@
+ci:
+  skip:
+    - lychee
+    - mypy
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -94,12 +99,11 @@ repos:
         args: ["-c", "pyproject.toml"]
         additional_dependencies: ["bandit[toml]"]
 
-  # TODO: Reenable this later. It is slow.
-  # - repo: https://github.com/owenlamont/lychee-pre-commit
-  #   rev: v0.24.2
-  #   hooks:
-  #     - id: lychee
-  #       args: ["--config", ".lychee.toml"]
+  - repo: https://github.com/owenlamont/lychee-pre-commit
+    rev: v0.24.2
+    hooks:
+      - id: lychee
+        args: ["--config", ".lychee.toml"]
 
   - repo: local
     hooks:


### PR DESCRIPTION
Re-enable the lychee link-checker hook by removing the commented block and slow TODO warning. Add a 'ci.skip' section for 'pre-commit.ci' so that 'lychee' (external network calls) and 'mypy' (extra dependencies) are skipped during automated pre-commit.ci runs.