### PR TITLE
ci(pre-commit): skip mypy and lychee hooks in GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run pre-commit
         if: matrix.os == 'ubuntu-latest'
-        run: uv run pre-commit run --all-files
+        run: SKIP=mypy,lychee uv run pre-commit run --all-files
 
       - name: Run tests (with coverage)
         if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
Set SKIP=mypy,lychee on the 'Run pre-commit' step in '.github/workflows/ci.yml' to bypass third-party link checking and mypy during automated pre-commit runner checks.