### PR TITLE
refactor(datetime): use replace for timestamp handling in area notices

### DIFF
--- a/ais_area_notice/imo_001_22_area_notice.py
+++ b/ais_area_notice/imo_001_22_area_notice.py
@@ -1842,14 +1842,7 @@ class AreaNotice(BBM):
             assert 0 <= area_type <= 127
             self.area_type = area_type
             assert isinstance(when, datetime.datetime)
-            self.when = datetime.datetime(
-                year=when.year,
-                month=when.month,
-                day=when.day,
-                hour=when.hour,
-                minute=when.minute,
-                tzinfo=when.tzinfo or datetime.UTC,
-            )
+            self.when = when.replace(second=0, microsecond=0)
             assert duration < 2**18 - 1
             self.duration = duration
             self.link_id = link_id
@@ -2091,14 +2084,13 @@ class AreaNotice(BBM):
 
         self.area_type = r["area_type"]
 
-        now = datetime.datetime.now(datetime.UTC)
-        self.when = datetime.datetime(
-            year=now.year,
+        self.when = datetime.datetime.now(datetime.UTC).replace(
             month=r["utc_month"],
             day=r["utc_day"],
             hour=r["utc_hour"],
             minute=r["utc_min"],
-            tzinfo=datetime.UTC,
+            second=0,
+            microsecond=0,
         )
         self.duration = r["duration_min"]
         self.link_id = r["link_id"]

--- a/ais_area_notice/m366_22.py
+++ b/ais_area_notice/m366_22.py
@@ -198,14 +198,7 @@ class AreaNotice:
             self.area_type = area_type
             assert when is not None
             # Leave out seconds.
-            self.when = datetime.datetime(
-                when.year,
-                when.month,
-                when.day,
-                when.hour,
-                when.minute,
-                tzinfo=when.tzinfo or datetime.UTC,
-            )
+            self.when = when.replace(second=0, microsecond=0)
             self.duration_min = duration_min
             self.link_id = link_id
             self.mmsi = mmsi
@@ -291,9 +284,13 @@ class AreaNotice:
         hour = db.get_int(5)
         minute = db.get_int(6)
         # TODO(schwehr): Handle year boundary.
-        now = datetime.datetime.now(datetime.UTC)
-        self.when = datetime.datetime(
-            now.year, month, day, hour, minute, tzinfo=datetime.UTC
+        self.when = datetime.datetime.now(datetime.UTC).replace(
+            month=month,
+            day=day,
+            hour=hour,
+            minute=minute,
+            second=0,
+            microsecond=0,
         )
         self.duration_min = db.get_int(18)
         # self.spare2 = db.GetInt(3)

--- a/ais_area_notice/m367_22.py
+++ b/ais_area_notice/m367_22.py
@@ -706,14 +706,7 @@ class AreaNotice(BBM):
             self.area_type = area_type
             assert when is not None
             # Leave out seconds.
-            self.when = datetime.datetime(
-                when.year,
-                when.month,
-                when.day,
-                when.hour,
-                when.minute,
-                tzinfo=when.tzinfo or datetime.UTC,
-            )
+            self.when = when.replace(second=0, microsecond=0)
             assert duration_min is not None
             self.duration_min = duration_min
             assert link_id is not None
@@ -853,9 +846,13 @@ class AreaNotice(BBM):
         hour = db.get_int(5)
         minute = db.get_int(6)
         # TODO(schwehr): Handle year boundary.
-        now = datetime.datetime.now(datetime.UTC)
-        self.when = datetime.datetime(
-            now.year, month, day, hour, minute, tzinfo=datetime.UTC
+        self.when = datetime.datetime.now(datetime.UTC).replace(
+            month=month,
+            day=day,
+            hour=hour,
+            minute=minute,
+            second=0,
+            microsecond=0,
         )
         self.duration_min = db.get_int(18)
         self.spare2 = db.get_int(3)


### PR DESCRIPTION
Update decode_bits in imo_001_22_area_notice.py, m366_22.py, and m367_22.py to construct timestamps via `datetime.now(datetime.UTC).replace(...)` and standardize second and microsecond zero-truncation across Area Notice implementations.