### PR TITLE
Fix exception handling for multiple error types

### DIFF
--- a/ais_area_notice/imo_001_22_area_notice.py
+++ b/ais_area_notice/imo_001_22_area_notice.py
@@ -2049,7 +2049,7 @@ class AreaNotice(BBM):
                 if msg_dict["checksum"] != nmea_checksum_hex(msg):
                     raise AisUnpackingException("Checksum failed")
                 msgs.append(msg_dict)
-        except AttributeError, TypeError:
+        except (AttributeError, TypeError):
             raise AisUnpackingException("one or more NMEA lines did were malformed (1)")
 
         bits_list = []


### PR DESCRIPTION
Python 2 syntax for catching multiple exception types (except AttributeError, TypeError:) is invalid in Python 3 and raises a fatal SyntaxError at parse time, breaking the module entirely.